### PR TITLE
CHORE: Remove CI install target

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           .venv\Scripts\Activate.ps1
           pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.2.20230527.dev0
-          pip install pypandoc-binary>=1.10.0,<1.14
+          pip install "pypandoc-binary>=1.10.0,<1.14"
 
       - name: Retrieve common toolkit version
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -86,7 +86,8 @@ jobs:
       - name: Install CI related dependencies
         run: |
           .venv\Scripts\Activate.ps1
-          pip install --extra-index-url https://wheels.vtk.org .[ci]
+          pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.2.20230527.dev0
+          pip install pypandoc-binary>=1.10.0,<1.14
 
       - name: Retrieve common toolkit version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,6 @@ doc = [
     "jupyterlab>=4.0.0,<4.3",
     "pypandoc>=1.10.0,<1.14",
 ]
-ci = [
-    "pypandoc-binary>=1.10.0,<1.14",
-    "vtk-osmesa==9.2.20230527.dev0",
-]
 
 [tool.flit.module]
 name = "ansys.aedt.toolkits.common"


### PR DESCRIPTION
Using the install target CI turned out to be a bad idea because combined with the `pip install .[ci]` command, it leads to the installation of both `vtk` and `vtk-osmesa` packages which can conflict with each other.