### PR TITLE
FIX: /create_geometry routes GET and POST 

### DIFF
--- a/examples/toolkit/pyaedt_toolkit/backend/run_backend.py
+++ b/examples/toolkit/pyaedt_toolkit/backend/run_backend.py
@@ -15,7 +15,7 @@ if len(sys.argv) == 3:
     toolkit_api.properties.port = int(sys.argv[2])
 
 
-@app.route("/create_geometry", methods=["POST"])
+@app.route("/create_geometry", methods=["GET","POST"])
 def create_geometry():
     logger.info("[POST] /create_geometry (create a box or sphere in HFSS).")
 


### PR DESCRIPTION
Fix to issue #194 

Fixed the route to add both methods. Note that in the future it'd be ideal that functions are split into the most simplistic expressions. This way creating webapps becomes a lot easier/straight forward. It's good practice to use tools like Postman for these tasks. In this case it's quite a simple case but it gets hairy very fast otherwise.

With this fix you'll get:

- When connecting to the backend
![image](https://github.com/user-attachments/assets/17be16da-5e7f-4fb3-8358-2a198fe2a3c0)


- When creating a geometry
![image](https://github.com/user-attachments/assets/05803db6-b8d3-4997-b697-7574c20c143c)

I didn't change the logger's message because I don't think we need an extra layer of complexity there.
