### PR TITLE
FIX: Temporary avoid attrs v24.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "pyaedt>=0.10.0,<0.12",
     "pydantic",
     "tomli; python_version < '3.12'",
+    # FIXME: Remove the following once https://github.com/python-attrs/attrs/issues/1386 is closed
+    "attrs!=24.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Description
Temporary solution for the packaging issue in CICD. This PR should be reverted at some point once attrs gets a new release with license available on PyPI.

Issue linked
Here is the issue associated to our CICD failure python-attrs/attrs#1386