### PR TITLE
CHORE: Cover only toolkits common backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ src_paths = ["doc", "src", "tests"]
 source = ["ansys.aedt.toolkits.common"]
 omit = [
     # Omit UI testing
-    "src/ansys/aedt/toolkits/common/backend/*,
+    "src/ansys/aedt/toolkits/common/ui/*,
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ src_paths = ["doc", "src", "tests"]
 source = ["ansys.aedt.toolkits.common"]
 omit = [
     # Omit UI testing
-    "src/ansys/aedt/toolkits/common/ui/*,
+    "src/ansys/aedt/toolkits/common/ui/*",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,11 @@ default_section = "THIRDPARTY"
 src_paths = ["doc", "src", "tests"]
 
 [tool.coverage.run]
-source = ["ansys.aedt"]
+source = ["ansys.aedt.toolkits.common"]
+omit = [
+    # Omit UI testing
+    "src/ansys/aedt/toolkits/common/backend/*,
+]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
There seem to be an issue with the coverage configuration. Previously, when PyAEDT was still installed in pyaedt it was not an issue but now that we are installing it as ansys.aedt.core, the coverage got mixed.
This changes should ensure that the project is checking the correct files coverage.