### PR TITLE
FEAT: Get Active Project in case no available active project

### DIFF
--- a/src/ansys/aedt/toolkits/common/backend/api.py
+++ b/src/ansys/aedt/toolkits/common/backend/api.py
@@ -558,6 +558,8 @@ class AEDTCommon(Common):
             project_name = self.get_project_name(project_name)
             active_design = design_name
             if design_name in self.properties.design_list[project_name]:
+                if not self.desktop.odesktop.GetActiveProject():  # pragma: no cover
+                    self.desktop.odesktop.SetActiveProject(project_name)
                 self.aedtapp = self.desktop[[project_name, design_name]]
                 if not self.aedtapp:  # pragma: no cover
                     self.release_aedt(False, False)


### PR DESCRIPTION
In some cases, in non-graphical mode, AEDT session could have multiple projects but none of them active (which should not be possible)

This prevents to have a session without an active project