### PR TITLE
CI: Add mandatory token to github release step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -255,6 +255,7 @@ jobs:
         uses: ansys/actions/release-github@v8
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-dev:
     name: "Deploy development documentation"


### PR DESCRIPTION
As title says, see [ansys actions migration guide](https://actions.docs.ansys.com/version/stable/migrations/index.html#version-v8)