### PR TITLE
CI: Add safety check to all dependencies

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -52,6 +52,7 @@ jobs:
           python-package-name: ${{ env.LIBRARY_NAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
+          extra-targets: 'all'
 
   # NOTE: We do not allow dependabot to trigger the CI/CD pipeline automatically.
   # This is to mitigate supply chain attacks, where a malicious dependency update

--- a/doc/changelog.d/290.maintenance.md
+++ b/doc/changelog.d/290.maintenance.md
@@ -1,0 +1,1 @@
+Add safety check to all dependencies


### PR DESCRIPTION
Add "all" dependencies to vulnerability action in the CICD