### PR TITLE
CI: Pin vtk-osmesa version

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,7 +20,7 @@ help:
 		@echo "Removing vtk to avoid conflicts with vtk-osmesa needed for CI/CD"; \
 		pip uninstall --yes vtk; \
 		@echo "Installing vtk-osmesa"; \
-		pip install --extra-index-url https://wheels.vtk.org vtk-osmesa; \
+		pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.1; \
 	fi
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/doc/changelog.d/296.maintenance.md
+++ b/doc/changelog.d/296.maintenance.md
@@ -1,0 +1,1 @@
+Pin vtk-osmesa version

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -23,7 +23,7 @@ if NOT "%is_vtk_osmesa_installed%" == "vtk-osmesa" if "%ON_CI%" == "true" (
 	@ECHO ON
 	echo "Installing vtk-osmesa"
 	@ECHO OFF
-	pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.2.20230527.dev0
+	pip install --extra-index-url https://wheels.vtk.org vtk-osmesa==9.3.1
 	)
 
 if "%1" == "" goto help


### PR DESCRIPTION
As title says. Avoid using non pinned version of `vtk-osmesa` to prevent supply chain attack.