### PR TITLE
TESTS: Fix flaky test using geometry thread

### DIFF
--- a/tests/ui/test_example_geometry_menu.py
+++ b/tests/ui/test_example_geometry_menu.py
@@ -54,8 +54,8 @@ def test_windows_create_geometry_with_default_values(mock_log, mock_post, patche
 
     # Wait for the geometry thread to finish and then check the post request
     geometry_thread = windows.geometry_menu.geometry_thread
-    with qtbot.waitSignal(geometry_thread.finished_signal, timeout=10000):
-        pass
+    assert geometry_thread.isRunning()
+    qtbot.waitUntil(lambda: not geometry_thread.isRunning(), timeout=20000)
     mock_post.assert_called_once_with(f"{DEFAULT_URL}/create_geometry", timeout=ANY)
 
     assert any("Creating geometry." in call.args[0] for call in mock_log.call_args_list)


### PR DESCRIPTION
Refactor the test using geometry thread to avoid random failure, see https://github.com/ansys/pyaedt-toolkits-common/actions/runs/17127510716/job/48583067989 for example.