### PR TITLE
FIX: Add ``ON_CI: True`` env variable to ``nightly-doc`` workflow

### DIFF
--- a/.github/workflows/nightly-doc.yml
+++ b/.github/workflows/nightly-doc.yml
@@ -10,6 +10,7 @@ env:
   MAIN_PYTHON_VERSION: '3.12'
   DOCUMENTATION_CNAME: 'aedt.common.toolkit.docs.pyansys.com'
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+  ON_CI: True
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +26,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Set up headless display
-        uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
+        uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
 
       - name: Build documentation
         uses: ansys/actions/doc-build@7d55ff0b9f67c77dae50a286d711ee1ae27b0a25 # v10.2.12

--- a/doc/changelog.d/410.fixed.md
+++ b/doc/changelog.d/410.fixed.md
@@ -1,0 +1,1 @@
+Add \`\`ON_CI: True\`\` env variable to \`\`nightly-doc\`\` workflow


### PR DESCRIPTION
This PR adds the ``ON_CI: True`` env variable to the ``nightly-doc.yml`` workflow file in order to fix the ``doc-build`` job. 
It is indeed failing (see for instance [here](https://github.com/ansys/pyaedt-toolkits-common/actions/runs/24067731389/job/70197304746)) due to a missing ``pypandoc-binary`` install which is performed in the ``make.bat`` (or ``Makefile``) if this environment variable is defined.

The ``pyvista/setup-headless-display-action`` version is also updated to ``v4.3`` in ``nightly-doc.yml`` to reflect the updated version already used in ``ci-pr.yml``.