### PR TITLE
CHORE: Update pyproject.toml

### DIFF
--- a/doc/changelog.d/418.maintenance.md
+++ b/doc/changelog.d/418.maintenance.md
@@ -1,0 +1,1 @@
+Update pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "pyaedt==1.0.0rc2",
+    "pyaedt",
     "pydantic>=2.0,<2.13",
     "tomli; python_version < '3.12'",
 ]
 
 [project.optional-dependencies]
 all = [
-    "pyaedt[all]==1.0.0rc2",
+    "pyaedt[all]",
     "flask",
     "pyside6==6.10.0",
     "pyqtgraph",
@@ -44,7 +44,7 @@ all = [
     "ansys-tools-visualization-interface[pyvistaqt]"
 ]
 tests = [
-    "pyaedt[all]==1.0.0rc2",
+    "pyaedt[all]",
     "flask",
     "pyside6==6.10.0",
     "pytest>=7.4.0,<9.1",


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to relax the version pinning for the `pyaedt` dependency, allowing for greater flexibility and compatibility with future versions. No other changes are included.

Dependency management:

* Unpinned the `pyaedt` and `pyaedt[all]` dependencies in both the main and optional dependencies, removing the strict requirement for version `1.0.0rc2`.