### PR TITLE
CHORE: Update Python version variable in CI configuration files

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -242,7 +242,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -7,7 +7,7 @@ on:
 
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  TESTS_PYTHON_VERSION: '3.10'
   ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
   ON_CI: True
 
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -117,7 +117,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -208,7 +208,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.TESTS_VERSION }}
+          python-version: ${{ env.TESTS_PYTHON_VERSION }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/doc/changelog.d/437.maintenance.md
+++ b/doc/changelog.d/437.maintenance.md
@@ -1,0 +1,1 @@
+Update Python version variable in CI configuration files


### PR DESCRIPTION
This pull request standardizes the environment variable used to specify the Python version across multiple GitHub Actions workflow files. The variable `TESTS_PYTHON_VERSION` is now used consistently instead of the previously used `TESTS_VERSION` or `MAIN_PYTHON_VERSION`. This change improves clarity and maintainability of the CI/CD configuration.

**Workflow variable standardization:**

* Updated all references to the Python version variable in `.github/workflows/ci-pr.yml`, `.github/workflows/nightly-test.yml`, and `.github/workflows/release.yml` to use `TESTS_PYTHON_VERSION` instead of `TESTS_VERSION` or `MAIN_PYTHON_VERSION`.

* Renamed the environment variable in `.github/workflows/nightly-test.yml` from `MAIN_PYTHON_VERSION` to `TESTS_PYTHON_VERSION` for consistency.