### PR TITLE
CHORE: Remove redundant virtual environment creation in CI workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -162,13 +162,8 @@ jobs:
           enable-cache: false
           prune-cache: true
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          .\.venv\Scripts\Activate.ps1
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5
@@ -192,14 +187,12 @@ jobs:
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m rest_api --cov --cov-append
 
       - name: Test utils
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m utils --cov --cov-append
 
       - name: Test UI
@@ -280,13 +273,8 @@ jobs:
             libxkbcommon-dev \
             libxkbcommon-x11-dev
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          source .venv/bin/activate
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -38,13 +38,8 @@ jobs:
           enable-cache: false
           prune-cache: true
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          .\.venv\Scripts\Activate.ps1
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5
@@ -68,14 +63,12 @@ jobs:
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m rest_api --cov --cov-append
 
       - name: Test utils
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m utils --cov --cov-append
 
       - name: Test UI
@@ -155,13 +148,8 @@ jobs:
             libxkbcommon-dev \
             libxkbcommon-x11-dev
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          source .venv/bin/activate
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,13 +129,8 @@ jobs:
           enable-cache: false
           prune-cache: true
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          .\.venv\Scripts\Activate.ps1
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5
@@ -159,14 +154,12 @@ jobs:
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m rest_api --cov --cov-append
 
       - name: Test utils
         timeout-minutes: 5
         run: |
           .\.venv\Scripts\Activate.ps1
-
           pytest -v -m utils --cov --cov-append
 
       - name: Test UI
@@ -246,13 +239,8 @@ jobs:
             libxkbcommon-dev \
             libxkbcommon-x11-dev
 
-      - name: Create virtual environment
-        run: uv venv .venv
-
       - name: Install packages for testing
-        run: |
-          source .venv/bin/activate
-          uv sync --frozen --group tests --extra all
+        run: uv sync --frozen --group tests --extra all
 
       - name: Test AEDT Common API
         timeout-minutes: 5

--- a/doc/changelog.d/441.maintenance.md
+++ b/doc/changelog.d/441.maintenance.md
@@ -1,0 +1,1 @@
+Remove redundant virtual environment creation in CI workflows


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflows for CI, nightly tests, and releases by removing explicit virtual environment creation and activation steps. The workflows now rely on the default environment setup when installing and running tests, streamlining the process and reducing redundancy.

**Workflow simplification:**

* Removed explicit creation of the virtual environment with `uv venv .venv` in all jobs across `.github/workflows/ci-pr.yml`, `.github/workflows/nightly-test.yml`, and `.github/workflows/release.yml`. 

* Eliminated the need to activate the virtual environment before installing packages or running tests. The `uv sync` and `pytest` commands are now run directly, assuming the appropriate environment is already active or not required.
* 
These changes make the workflow files cleaner and reduce the chance of environment-related issues during CI and release processes.