### PR TITLE
CI: Configure dependabot to skip patch release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,10 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "BUILD(uv)"
 
@@ -96,6 +100,10 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "BUILD(actions)"
 
@@ -127,5 +135,9 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "BUILD(pre-commit)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,9 +66,50 @@ updates:
       - "maintenance"
       - "dependencies"
     ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+      - dependency-name: "flask"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pyqtgraph"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pyside6"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "qdarkstyle"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "tomli"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "ipython"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "ipywidgets"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "jupyterlab"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "jupytext"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "nbsphinx"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "numpydoc"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pypandoc"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "recommonmark"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "Sphinx"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "sphinx-autobuild"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "sphinx-copybutton"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "sphinx_design"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "prek"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pytest"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pytest-cov"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pytest-qt"
+        update-types: ["version-update:semver-patch"]
     commit-message:
       prefix: "BUILD(uv)"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,9 +142,18 @@ updates:
       - "maintenance"
       - "dependencies"
     ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+      - dependency-name: "actions/*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "astral-sh/*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "codecov/*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "micnncim/*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "peter-evans/*"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "pypa/*"
+        update-types: ["version-update:semver-patch"]
     commit-message:
       prefix: "BUILD(actions)"
 
@@ -177,8 +186,21 @@ updates:
       - "maintenance"
       - "dependencies"
     ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+      - dependency-name: "https://github.com/adamchainz/blacken-docs"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/codespell-project/codespell"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/pre-commit/pre-commit-hooks"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/pre-commit-ci/pre-commit-ci-config"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/psf/black"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/PyCQA/flake8"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/pycqa/isort"
+        update-types: ["version-update:semver-patch"]
+      - dependency-name: "https://github.com/python-jsonschema/check-jsonschema"
+        update-types: ["version-update:semver-patch"]
     commit-message:
       prefix: "BUILD(pre-commit)"

--- a/doc/changelog.d/469.maintenance.md
+++ b/doc/changelog.d/469.maintenance.md
@@ -1,0 +1,1 @@
+Configure dependabot to skip patch release


### PR DESCRIPTION
As title says. Should lower the number of bumps that we see coming while keeping the ability to have bumps related to ansys projects (even with patch bumps).
