### PR TITLE
CI: Bump pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
           path: ${{ env.LIBRARY_NAME }}-artifacts
 
       - name: Release to PyPI using trusted publisher
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: "https://upload.pypi.org/legacy/"
           print-hash: true

--- a/doc/changelog.d/498.maintenance.md
+++ b/doc/changelog.d/498.maintenance.md
@@ -1,0 +1,1 @@
+Bump pypa/gh-action-pypi-publish


### PR DESCRIPTION
As title says. There were some bug fix in follow releases and we might be hitting one of this issues with our current release process.