### PR TITLE
FIX: corrected the header for the aedt project open which was using default header name of pyside6

### DIFF
--- a/doc/changelog.d/499.fixed.md
+++ b/doc/changelog.d/499.fixed.md
@@ -1,0 +1,1 @@
+Corrected the header for the aedt project open which was using default header name of pyside6

--- a/src/ansys/aedt/toolkits/common/ui/common_windows/settings_column.py
+++ b/src/ansys/aedt/toolkits/common/ui/common_windows/settings_column.py
@@ -309,7 +309,7 @@ class SettingsMenu(QObject):
         options = QFileDialog.Options()
         file, _ = QFileDialog.getOpenFileName(
             self.ui.app,
-            "QFileDialog.getOpenFileName()",
+            "Open AEDT Project",
             "",
             "Ansys Electronics Desktop Project Files (*.aedt *.aedtz)",
             options=options,


### PR DESCRIPTION
<img width="540" height="448" alt="image" src="https://github.com/user-attachments/assets/a029ffdc-e9a3-4656-b6e1-a4f9481337f2" />
